### PR TITLE
Use auth for tag searches

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -355,7 +355,7 @@ class Instagram
      */
     public function searchTags($name)
     {
-        return $this->_makeCall('tags/search', false, array('q' => $name));
+        return $this->_makeCall('tags/search', true, array('q' => $name));
     }
 
     /**
@@ -386,7 +386,7 @@ class Instagram
             $params['count'] = $limit;
         }
 
-        return $this->_makeCall('tags/' . $name . '/media/recent', false, $params);
+        return $this->_makeCall('tags/' . $name . '/media/recent', true, $params);
     }
 
     /**


### PR DESCRIPTION
Based on my experience, these tag searches require the access_token.